### PR TITLE
settings: redirect all HTTP requests to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,13 @@ Now, create a file in the top-level of the directoy, `.env`, and put all of the
 variables printed out from `heroku config` in the file in the following format.
 You can skip the DATABASE_URL parameter, since heroku takes care of that
 locally. As can be implied, **you should never commit and/or push this file**.
+In order for local development to work, you **must** put `Debug='True'` into the
+file, this this then turns off mandatory SSL encryption which doesn't work
+locally.
 ```
-DJANGO_SECRET_KEY="YYYY"
-GOOGLE_MAPS_API_KEY="ZZZZ"
+DJANGO_SECRET_KEY='YYYY'
+GOOGLE_MAPS_API_KEY='ZZZZ'
+DEBUG='True'
 ...
 ```
 

--- a/app.json
+++ b/app.json
@@ -9,7 +9,8 @@
     },
     "GOOGLE_MAPS_API_KEY" : {
       "required": true
-    }
+    },
+    "DEBUG" : "True"
   },
   "formation": {
   },
@@ -20,5 +21,8 @@
     {
       "url": "heroku/python"
     }
-  ]
+  ],
+  "scripts" : {
+      "postdeploy": "python manage.py migrate"
+  }
 }

--- a/jennanddan/settings.py
+++ b/jennanddan/settings.py
@@ -23,8 +23,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = (os.environ.get('DEBUG') == 'True')
 
 ALLOWED_HOSTS = [
     '.herokuapp.com',
@@ -145,3 +144,7 @@ STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 # For Easy Maps
 EASY_MAPS_GOOGLE_MAPS_API_KEY = os.environ.get('GOOGLE_MAPS_API_KEY')
 EASY_MAPS_CENTER = (-41.3, 32)
+
+# Redirect all HTTP requests to HTTPS. If running in debug mode turn this off,
+#   otherwise require it s.t. the site is secure.
+SECURE_SSL_REDIRECT = not DEBUG


### PR DESCRIPTION
Will automatically move all HTTP requests to HTTPS if not in
debug mode. Debug mode is now implied false unless explicitly
turned on in the environment.